### PR TITLE
Cipher List Setting

### DIFF
--- a/Sources/OpenSSL/ClientContext.swift
+++ b/Sources/OpenSSL/ClientContext.swift
@@ -30,22 +30,12 @@ public final class SSLClientContext: Context {
     public init(verifyBundle: String? = nil,
       certificate: String? = nil,
       privateKey: String? = nil,
-      certificateChain: String? = nil,
-      cipherList: String? = nil) throws {
+      certificateChain: String? = nil) throws {
 		try super.init(method: .SSLv23, type: .Client)
 
         SSL_CTX_set_verify(context, SSL_VERIFY_PEER, nil)
         SSL_CTX_set_verify_depth(context, 4)
         SSL_CTX_set_options(context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION)
-
-        var sslCipherList = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"
-        if let cipherList = cipherList {
-          sslCipherList = cipherList
-        }
-        if SSL_CTX_set_cipher_list(context, sslCipherList) != 1 {
-            throw Context.Error.Certificate(description: lastSSLErrorDescription)
-        }
-
 
         if SSL_CTX_set_default_verify_paths(context) != 1 {
             throw Context.Error.Certificate(description: lastSSLErrorDescription)

--- a/Sources/OpenSSL/ClientContext.swift
+++ b/Sources/OpenSSL/ClientContext.swift
@@ -27,16 +27,25 @@ import COpenSSL
 typealias CCallback = @convention(c) Void -> Void
 
 public final class SSLClientContext: Context {
-    public init(verifyBundle: String? = nil, certificate: String? = nil, privateKey: String? = nil, certificateChain: String? = nil) throws {
+    public init(verifyBundle: String? = nil,
+      certificate: String? = nil,
+      privateKey: String? = nil,
+      certificateChain: String? = nil,
+      cipherList: String? = nil) throws {
 		try super.init(method: .SSLv23, type: .Client)
 
         SSL_CTX_set_verify(context, SSL_VERIFY_PEER, nil)
         SSL_CTX_set_verify_depth(context, 4)
         SSL_CTX_set_options(context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION)
 
-        if SSL_CTX_set_cipher_list(context, "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4") != 1 {
+        var sslCipherList = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"
+        if let cipherList = cipherList {
+          sslCipherList = cipherList
+        }
+        if SSL_CTX_set_cipher_list(context, sslCipherList) != 1 {
             throw Context.Error.Certificate(description: lastSSLErrorDescription)
         }
+
 
         if SSL_CTX_set_default_verify_paths(context) != 1 {
             throw Context.Error.Certificate(description: lastSSLErrorDescription)


### PR DESCRIPTION
# Problem

can not connect some site. e.g. https://echo.websocket.org
https://www.ssllabs.com/ssltest/analyze.html?d=echo.websocket.org
Safari can respond 404 but HTTPSClient reset connection by peer
# Reason

default cipher list `"HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"` is strict
so some server does not reach its requirement.
# Fix

Able to set cipherList from HTTPSClient it can pass to TCPSSL and then
OpenSSL

it does not break current program because it uses `cipherList: String?
= nil` so exsist code runs exactly it was before.
