### PR TITLE
Fix for rand() error in Swift 3

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,7 +4,8 @@ import XCTest
 @testable import OpenSSLTestSuite
 
 XCTMain([
-    testCase(OpenSSLTests.allTests)
+    testCase(OpenSSLTests.allTests),
+    testCase(CertificateTests.allTests)
 ])
 
 #endif

--- a/Tests/OpenSSL/CertificateTests.swift
+++ b/Tests/OpenSSL/CertificateTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import OpenSSL
+
+class CertificateTests: XCTestCase {
+    /**
+        Test for https://github.com/Zewo/OpenSSL/pull/20
+    */
+    func testRand() throws {
+        let key = Key(keyLength: 2048)
+        let cn = "example.com"
+        
+        let cert = try Certificate(privateKey:key, commonName:cn)
+        
+        let first = cert.rand()
+        let second = cert.rand()
+        
+        XCTAssert(
+            first != second,
+            "Two successive random numbers really shouldn't be the same"
+        )
+    }
+}
+
+extension CertificateTests {
+    static var allTests: [(String, (CertificateTests) -> () throws -> Void)] {
+        return [
+            ("testRand", testRand),
+        ]
+    }
+}

--- a/Tests/OpenSSL/OpenSSLTests.swift
+++ b/Tests/OpenSSL/OpenSSLTests.swift
@@ -10,7 +10,7 @@ class OpenSSLTests: XCTestCase {
 extension OpenSSLTests {
 	static var allTests: [(String, (OpenSSLTests) -> () throws -> Void)] {
 		return [
-		   ("testReality", testReality),
+            ("testReality", testReality),
 		]
 	}
 }


### PR DESCRIPTION
When playing with a package that was related to this package, I found that Swift 3 gave the following error:

```
/Users/mhughes/Projects/Kitura/Packages/OpenSSL-0.8.4/Sources/OpenSSL/Certificate.swift:86:16: error: 'rand()' is unavailable in Swift: Use arc4random instead.
                let serial = rand()
                             ^~~~
Darwin.rand:2:13: note: 'rand()' has been explicitly marked unavailable here
public func rand() -> Int32
            ^
<unknown>:0: error: build had 1 command failures
```

This patch makes that small change.
